### PR TITLE
Collect DJHQ MCP repo stats on a daily basis

### DIFF
--- a/.github/workflows/djhq-mcp-stats.yml
+++ b/.github/workflows/djhq-mcp-stats.yml
@@ -1,0 +1,18 @@
+name: djhq-mcp-stats
+
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  j1:
+    name: djhq-mcp-stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          ghtoken: ${{ secrets.ghrs_github_api_token }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the collection of repository statistics. The workflow is scheduled to run daily and can also be triggered manually.

**New workflow for repository statistics:**

* Added `.github/workflows/djhq-mcp-stats.yml` to schedule a daily job (at 23:00 UTC) and allow manual runs for collecting GitHub repository statistics using the `jgehrcke/github-repo-stats` action, with authentication via a repository secret.