### PR TITLE
Update djhq-mcp-stats.yml

### DIFF
--- a/.github/workflows/djhq-mcp-stats.yml
+++ b/.github/workflows/djhq-mcp-stats.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   j1:
-    name: djhq-mcp-stats
+    name: github-repo-stats
     runs-on: ubuntu-latest
     steps:
       - name: run-ghrs


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/djhq-mcp-stats.yml` file by renaming the job from `djhq-mcp-stats` to `github-repo-stats`.